### PR TITLE
fix(gpio): GPIO close on graceful shutdown

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,4 +28,5 @@ async def generate_openapi():
 @app.on_event("shutdown")
 async def shutdown_event():
     logger.info("Shutting down...")
-    Device.close()
+    # Close the GPIO device when the application shuts down
+    settings.DEVICE.close()

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,4 +1,6 @@
 from typing import Union
+from gpiozero import Device
+
 
 from .logger import logger
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -16,6 +18,7 @@ class Config(BaseSettings):
     PUMP_GPIO: str
     DEBUG_LEVEL: str = 'INFO'
     GPIO_MODE: str = ""
+    DEVICE: Union[Device, None] = None
     
     model_config = SettingsConfigDict(env_file=".env.local")
 
@@ -23,10 +26,10 @@ settings = Config()
 
 logger.setLevel(settings.DEBUG_LEVEL.upper()) 
 
-logger.debug(f"Start project with current configuration \n {settings.model_dump()}")
+logger.debug(f"Start project with current configuration \n {settings.model_dump_json(indent=2)}")
 
 if settings.GPIO_MODE.lower() == "mock":
-    from gpiozero import Device
     from gpiozero.pins.mock import MockFactory, MockPWMPin
     logger.debug("Use mock GPIO mode")
     Device.pin_factory = MockFactory(pin_class=MockPWMPin)
+    settings.DEVICE = Device()


### PR DESCRIPTION
- Updated shutdown event to close the GPIO device using settings.DEVICE.
- Added DEVICE attribute to the Config class to manage the GPIO device instance.
- Enhanced logging of the current configuration to output JSON format for better readability.

Issue #29