### PR TITLE
ci(docker): simplify Docker publish workflow by removing matrix strategy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,11 +25,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     permissions:
       contents: read
       packages: write
@@ -38,11 +33,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
-      
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -97,7 +87,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64, linux/amd64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
- Removed the matrix strategy for platform builds, simplifying the workflow.
- Updated the platforms variable to explicitly list `linux/arm64` and `linux/amd64`.
- Cleaned up unnecessary steps related to platform preparation.