### PR TITLE
refactor(models): unify actuator state attributes into a single `stat…

### DIFF
--- a/app/models/actuators.py
+++ b/app/models/actuators.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Literal, TypeVar
 from enum import Enum
 from pydantic import BaseModel, Field
 
@@ -21,22 +21,22 @@ class Actuator(BaseModel):
 class SolenoidValve(Actuator):
     """Model representing a solenoid valve actuator."""
 
-    type: ActuatorEnum = ActuatorEnum.SOLENOID
-    open: bool
+    type: Literal[ActuatorEnum.SOLENOID] = ActuatorEnum.SOLENOID
+    state: bool
 
 
 class ProportionalValve(Actuator):
     """Model representing a proportional valve actuator."""
 
-    type: ActuatorEnum = ActuatorEnum.PROPORTIONAL
-    position: int = Field(..., ge=0, le=100)
+    type: Literal[ActuatorEnum.PROPORTIONAL] = ActuatorEnum.PROPORTIONAL
+    state: float = Field(..., ge=0, le=100)
 
 
 class Pump(Actuator):
     """Model representing a pump actuator."""
 
-    type: ActuatorEnum = ActuatorEnum.PUMP
-    running: bool
+    type: Literal[ActuatorEnum.PUMP] = ActuatorEnum.PUMP
+    state: bool
 
 
 T = TypeVar("T", bound=Actuator)

--- a/app/models/sensors.py
+++ b/app/models/sensors.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, TypeVar, Union
+from typing import Generic, List, Literal, TypeVar, Union
 from enum import Enum
 from pydantic import BaseModel, Field
 
@@ -32,7 +32,7 @@ class Sensor(BaseModel):
 class Flowmeter(Sensor):
     """Model for a flowmeter sensor."""
 
-    type: SensorEnum = SensorEnum.FLOWMETER
+    type: Literal[SensorEnum.FLOWMETER] = SensorEnum.FLOWMETER
     unit: str = "l/min"
 
 

--- a/app/repositories/actuators/CAN/proportional_valves.py
+++ b/app/repositories/actuators/CAN/proportional_valves.py
@@ -126,12 +126,12 @@ class ProportionalActuator(ActuatorRepository):
         rounded_position = round(self.position)
         clipped_position = max(0, min(100, rounded_position))
 
-        return ProportionalValve(id=actuator_id, position=clipped_position)
+        return ProportionalValve(id=actuator_id, state=clipped_position)
 
     def set_state(self, actuator: ProportionalValve):
         # Assuming you set command using TPDO and RPDO data
-        self.position_command.phys = actuator.position
-        logger.debug(f"Proportional {actuator.id} set to {actuator.position}")
+        self.position_command.phys = actuator.state
+        logger.debug(f"Proportional {actuator.id} set to {actuator.state}")
 
         return actuator
 

--- a/app/repositories/actuators/GPIO/proportional_valves.py
+++ b/app/repositories/actuators/GPIO/proportional_valves.py
@@ -21,7 +21,7 @@ class ProportionalActuator(ActuatorRepository):
     def get_all(self) -> List[ProportionalValve]:
         values: List[float] = self.proportionals.value
         proportional_valves: List[ProportionalValve] = [
-            ProportionalValve(id=i, position=round(val * self.factor))
+            ProportionalValve(id=i, state=round(val * self.factor))
             for i, val in enumerate(values)
         ]
         logger.debug("Proportional valves: %s", proportional_valves)
@@ -30,13 +30,13 @@ class ProportionalActuator(ActuatorRepository):
     def get_by_id(self, actuator_id: int) -> ProportionalValve:
         state: int = round(self.proportionals[actuator_id].value * self.factor)
         proportional_valve: ProportionalValve = ProportionalValve(
-            id=actuator_id, position=state
+            id=actuator_id, state=state
         )
 
         return proportional_valve
 
     def set_state(self, actuator: ProportionalValve):
-        request_state: float = float(actuator.position) / self.factor
+        request_state: float = float(actuator.state) / self.factor
 
         if actuator.id == -1:
             # Set state for all proportionals
@@ -46,4 +46,4 @@ class ProportionalActuator(ActuatorRepository):
 
         logger.debug("Proportional %s set to %s", actuator.id, request_state)
         new_state: int = round(self.proportionals[actuator.id].value * self.factor)
-        return ProportionalValve(id=actuator.id, position=new_state)
+        return ProportionalValve(id=actuator.id, state=new_state)

--- a/app/repositories/actuators/GPIO/pumps.py
+++ b/app/repositories/actuators/GPIO/pumps.py
@@ -14,19 +14,19 @@ class PumpActuator(ActuatorRepository):
 
     def get_all(self) -> List[Pump]:
         values: List[bool] = self.pumps.value
-        pumps: List[Pump] = [Pump(id=i, running=val) for i, val in enumerate(values)]
+        pumps: List[Pump] = [Pump(id=i, state=val) for i, val in enumerate(values)]
         logger.debug(f"Pumps: {pumps}")
 
         return pumps
 
     def get_by_id(self, id: int) -> Pump:
         state: bool = self.pumps[id].value
-        solenoid_valve: Pump = Pump(id=id, running=state)
+        solenoid_valve: Pump = Pump(id=id, state=state)
 
         return solenoid_valve
 
     def set_state(self, request: Pump):
-        request_state: bool = request.running
+        request_state: bool = request.state
 
         if request.id == -1:
             # Set state for all solenoids
@@ -35,4 +35,4 @@ class PumpActuator(ActuatorRepository):
             self.pumps[request.id].value = request_state
 
         logger.debug(f"Pump {request.id} set to {request_state}")
-        return Pump(id=request.id, running=self.pumps.value[request.id])
+        return Pump(id=request.id, state=self.pumps.value[request.id])

--- a/app/repositories/actuators/GPIO/solenoid_valves.py
+++ b/app/repositories/actuators/GPIO/solenoid_valves.py
@@ -15,7 +15,7 @@ class SolenoidActuator(ActuatorRepository):
     def get_all(self) -> List[SolenoidValve]:
         values: List[bool] = self.solenoids.value
         solenoid_valves: List[SolenoidValve] = [
-            SolenoidValve(id=i, open=val) for i, val in enumerate(values)
+            SolenoidValve(id=i, state=val) for i, val in enumerate(values)
         ]
         logger.debug(f"Solenoid valves: {solenoid_valves}")
 
@@ -23,12 +23,12 @@ class SolenoidActuator(ActuatorRepository):
 
     def get_by_id(self, id: int) -> SolenoidValve:
         state: bool = self.solenoids[id].value
-        solenoid_valve: SolenoidValve = SolenoidValve(id=id, open=state)
+        solenoid_valve: SolenoidValve = SolenoidValve(id=id, state=state)
 
         return solenoid_valve
 
     def set_state(self, request: SolenoidValve):
-        request_state: bool = request.open
+        request_state: bool = request.state
 
         if request.id == -1:
             # Set state for all solenoids
@@ -37,4 +37,4 @@ class SolenoidActuator(ActuatorRepository):
             self.solenoids[request.id].value = request_state
 
         logger.debug(f"Solenoid {request.id} set to {request_state}")
-        return SolenoidValve(id=request.id, open=self.solenoids.value[request.id])
+        return SolenoidValve(id=request.id, state=self.solenoids.value[request.id])

--- a/app/tests/test_actuators_endpoint.py
+++ b/app/tests/test_actuators_endpoint.py
@@ -17,9 +17,9 @@ def setup_test_client():
 
 
 def test_get_all_actuators(client, mocker):
-    expected_solenoid = [SolenoidValve(id=1, open=False)]
-    expected_proportional = [ProportionalValve(id=2, position=42)]
-    expected_pump = [Pump(id=3, running=True)]
+    expected_solenoid = [SolenoidValve(id=1, state=False)]
+    expected_proportional = [ProportionalValve(id=2, state=42)]
+    expected_pump = [Pump(id=3, state=True)]
 
     mocker.patch.object(SolenoidService, "get_all", return_value=expected_solenoid)
     mocker.patch.object(
@@ -38,7 +38,7 @@ def test_get_all_actuators(client, mocker):
 
 
 def test_solenoid_get_all(client, mocker):
-    expected = [SolenoidValve(id=1, open=True), SolenoidValve(id=2, open=False)]
+    expected = [SolenoidValve(id=1, state=True), SolenoidValve(id=2, state=False)]
     mocker.patch.object(
         SolenoidService,
         "get_all",
@@ -54,7 +54,7 @@ def test_solenoid_get_all(client, mocker):
 
 
 def test_solenoid_get_by_id(client, mocker):
-    expected = SolenoidValve(id=1, open=True)
+    expected = SolenoidValve(id=1, state=True)
     mocker.patch.object(
         SolenoidService,
         "get_by_id",
@@ -80,13 +80,13 @@ def test_solenoid_set(client, mocker):
     )
 
     # Test setting state to False
-    expected = SolenoidValve(id=42, open=False)
+    expected = SolenoidValve(id=42, state=False)
     response = client.post("/solenoid/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = SolenoidValve(**response.json())
     assert actual == expected
     # Test setting state to True
-    expected = SolenoidValve(id=24, open=True)
+    expected = SolenoidValve(id=24, state=True)
     response = client.post("/solenoid/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = SolenoidValve(**response.json())
@@ -94,7 +94,7 @@ def test_solenoid_set(client, mocker):
 
 
 def test_solenoid_set_request_invalid(client):
-    requests = [Pump(id=1, running=True), ProportionalValve(id=1, position=42)]
+    requests = [Pump(id=1, state=True), ProportionalValve(id=1, state=42)]
 
     for request in requests:
         with pytest.raises(RequestValidationError) as exc_info:
@@ -104,8 +104,8 @@ def test_solenoid_set_request_invalid(client):
 
 def test_proportional_get_all(client, mocker):
     expected = [
-        ProportionalValve(id=1, position=42),
-        ProportionalValve(id=2, position=24),
+        ProportionalValve(id=1, state=42),
+        ProportionalValve(id=2, state=24),
     ]
 
     mocker.patch.object(
@@ -123,7 +123,7 @@ def test_proportional_get_all(client, mocker):
 
 
 def test_proportional_get_by_id(client, mocker):
-    expected = ProportionalValve(id=1, position=42)
+    expected = ProportionalValve(id=1, state=42)
     mocker.patch.object(
         ProportionalService,
         "get_by_id",
@@ -149,14 +149,14 @@ def test_proportional_set(client, mocker):
     )
 
     # Test setting position to 42
-    expected = ProportionalValve(id=1, position=42)
+    expected = ProportionalValve(id=1, state=42)
     response = client.post("/proportional/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = ProportionalValve(**response.json())
     assert actual == expected
 
     # Test setting position to 24
-    expected = ProportionalValve(id=2, position=24)
+    expected = ProportionalValve(id=2, state=24)
     response = client.post("/proportional/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = ProportionalValve(**response.json())
@@ -165,8 +165,8 @@ def test_proportional_set(client, mocker):
 
 def test_proportional_set_request_invalid(client):
     requests = [
-        Pump(id=1, running=True),  # invalid request for ProportionalValve endpoint
-        SolenoidValve(id=3, open=False),
+        Pump(id=1, state=True),  # invalid request for ProportionalValve endpoint
+        SolenoidValve(id=3, state=False),
     ]
 
     for request in requests:
@@ -177,8 +177,8 @@ def test_proportional_set_request_invalid(client):
 
 def test_pump_get_all(client, mocker):
     expected = [
-        Pump(id=1, running=True),
-        Pump(id=2, running=False),
+        Pump(id=1, state=True),
+        Pump(id=2, state=False),
     ]
 
     mocker.patch.object(
@@ -206,13 +206,13 @@ def test_pump_set(client, mocker):
     )
 
     # Test setting state to True
-    expected = Pump(id=1, running=True)
+    expected = Pump(id=1, state=True)
     response = client.post("/pump/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = Pump(**response.json())
     assert actual == expected
     # Test setting state to False
-    expected = Pump(id=2, running=False)
+    expected = Pump(id=2, state=False)
     response = client.post("/pump/set", data=expected.model_dump_json())
     assert response.status_code == 200
     actual = Pump(**response.json())
@@ -220,7 +220,7 @@ def test_pump_set(client, mocker):
 
 
 def test_pump_get_by_id(client, mocker):
-    expected = Pump(id=1, running=True)
+    expected = Pump(id=1, state=True)
 
     mocker.patch.object(
         PumpService,
@@ -236,8 +236,8 @@ def test_pump_get_by_id(client, mocker):
 
 def test_pump_set_request_invalid(client):
     requests = [
-        ProportionalValve(id=1, position=42),  # invalid request for Pump endpoint
-        SolenoidValve(id=2, open=True),
+        ProportionalValve(id=1, state=42),  # invalid request for Pump endpoint
+        SolenoidValve(id=2, state=True),
     ]
 
     for request in requests:

--- a/app/tests/test_gpio_repositories.py
+++ b/app/tests/test_gpio_repositories.py
@@ -42,19 +42,19 @@ def test_solenoid_actuator(solenoid_actuator):
     solenoids = solenoid_actuator.get_all()
     assert len(solenoids) == 4
     for i in range(len(solenoids)):
-        assert solenoids[i].open == solenoid_actuator.solenoids[i].value
+        assert solenoids[i].state == solenoid_actuator.solenoids[i].value
     
     # Test get_by_id
     solenoid_actuator.solenoids[1].value = False
     solenoid = solenoid_actuator.get_by_id(1)
     assert solenoid.id == 1
-    assert solenoid.open is False
+    assert solenoid.state is False
 
     # Test set_state
     assert solenoid_actuator.solenoids[3].value == 0
-    solenoid_actuator.set_state(SolenoidValve(id=3, open=True))
+    solenoid_actuator.set_state(SolenoidValve(id=3, state=True))
     assert solenoid_actuator.solenoids[3].value == 1
-    solenoid_actuator.set_state(SolenoidValve(id=-1, open=False))
+    solenoid_actuator.set_state(SolenoidValve(id=-1, state=False))
     assert solenoid_actuator.solenoids.value == (0,0,0,0)
 
 
@@ -65,19 +65,19 @@ def test_pump_actuator(pump_actuator):
     pumps = pump_actuator.get_all()
     assert len(pumps) == 4
     for i in range(len(pumps)):
-        assert pumps[i].running == pump_actuator.pumps[i].value
+        assert pumps[i].state == pump_actuator.pumps[i].value
     
     # Test get_by_id
     pump_actuator.pumps[2].value = True
     pump = pump_actuator.get_by_id(2)
     assert pump.id == 2
-    assert pump.running is True
+    assert pump.state is True
 
     # Test set_state
     assert pump_actuator.pumps[3].value == 1
-    pump_actuator.set_state(Pump(id=3, running=False))
+    pump_actuator.set_state(Pump(id=3, state=False))
     assert pump_actuator.pumps[3].value == 0
-    assert pump_actuator.set_state(Pump(id=-1, running=True))
+    assert pump_actuator.set_state(Pump(id=-1, state=True))
     assert pump_actuator.pumps.value == (1,1,1,1)
 
 
@@ -88,17 +88,17 @@ def test_proportional_actuator(proportional_actuator):
     valves = proportional_actuator.get_all()
     assert len(valves) == 4
     for i in range(len(valves)):
-        assert valves[i].position == initial_values[i] * proportional_actuator.factor
+        assert valves[i].state == initial_values[i] * proportional_actuator.factor
     
     # Test get_by_id
     proportional_actuator.proportionals[3].value = 0.80
     valve = proportional_actuator.get_by_id(3)
     assert valve.id == 3
-    assert valve.position == 80
+    assert valve.state == 80
 
     # Test set_state
     assert proportional_actuator.proportionals[2].value == 0.5
-    proportional_actuator.set_state(ProportionalValve(id=2, position=100))
+    proportional_actuator.set_state(ProportionalValve(id=2, state=100))
     assert proportional_actuator.proportionals[2].value == 1.0
-    proportional_actuator.set_state(ProportionalValve(id=-1, position=50))
+    proportional_actuator.set_state(ProportionalValve(id=-1, state=50))
     assert proportional_actuator.proportionals.value == (0.50, 0.50, 0.50, 0.50)

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -552,25 +552,20 @@
   },
   "components": {
     "schemas": {
-      "ActuatorEnum": {
-        "type": "string",
-        "enum": [
-          "solenoid valve",
-          "proportional valve",
-          "pump"
-        ],
-        "title": "ActuatorEnum",
-        "description": "Enumeration for different types of actuators."
-      },
       "Flowmeter": {
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/SensorEnum",
+            "type": "string",
+            "enum": [
+              "flowmeter"
+            ],
+            "const": "flowmeter",
+            "title": "Type",
             "default": "flowmeter"
           },
           "id": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Id",
             "examples": [
               0,
@@ -617,12 +612,17 @@
       "ProportionalValve": {
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/ActuatorEnum",
+            "type": "string",
+            "enum": [
+              "proportional valve"
+            ],
+            "const": "proportional valve",
+            "title": "Type",
             "default": "proportional valve"
           },
           "id": {
             "type": "integer",
-            "minimum": -1,
+            "minimum": -1.0,
             "title": "Id",
             "examples": [
               0,
@@ -630,17 +630,17 @@
               2
             ]
           },
-          "position": {
-            "type": "integer",
-            "maximum": 100,
-            "minimum": 0,
-            "title": "Position"
+          "state": {
+            "type": "number",
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "State"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "position"
+          "state"
         ],
         "title": "ProportionalValve",
         "description": "Model representing a proportional valve actuator."
@@ -648,12 +648,17 @@
       "Pump": {
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/ActuatorEnum",
+            "type": "string",
+            "enum": [
+              "pump"
+            ],
+            "const": "pump",
+            "title": "Type",
             "default": "pump"
           },
           "id": {
             "type": "integer",
-            "minimum": -1,
+            "minimum": -1.0,
             "title": "Id",
             "examples": [
               0,
@@ -661,27 +666,18 @@
               2
             ]
           },
-          "running": {
+          "state": {
             "type": "boolean",
-            "title": "Running"
+            "title": "State"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "running"
+          "state"
         ],
         "title": "Pump",
         "description": "Model representing a pump actuator."
-      },
-      "SensorEnum": {
-        "type": "string",
-        "enum": [
-          "flowmeter"
-        ],
-        "const": "flowmeter",
-        "title": "SensorEnum",
-        "description": "Enumeration for different types of sensors."
       },
       "SensorReading": {
         "properties": {
@@ -709,12 +705,17 @@
       "SolenoidValve": {
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/ActuatorEnum",
+            "type": "string",
+            "enum": [
+              "solenoid valve"
+            ],
+            "const": "solenoid valve",
+            "title": "Type",
             "default": "solenoid valve"
           },
           "id": {
             "type": "integer",
-            "minimum": -1,
+            "minimum": -1.0,
             "title": "Id",
             "examples": [
               0,
@@ -722,15 +723,15 @@
               2
             ]
           },
-          "open": {
+          "state": {
             "type": "boolean",
-            "title": "Open"
+            "title": "State"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "open"
+          "state"
         ],
         "title": "SolenoidValve",
         "description": "Model representing a solenoid valve actuator."


### PR DESCRIPTION
…e` field

- solves #62
- Updated actuator models to use a unified `state` field instead of specific attributes.
- Refactored repository logic and tests accordingly.
- This change affects downstream systems and clients that consume these models.  Ensure updates are made to handle the new `state` attribute.

BREAKING CHANGE: The following actuator-specific state attributes have been replaced:
- `SolenoidValve`: `open` -> `state` (bool)
- `Pump`: `running` -> `state` (bool)
- `ProportionalValve`: `position` -> `state` (float)